### PR TITLE
Changing AVD host pool API version 

### DIFF
--- a/Bicep/child_modules/avd.bicep
+++ b/Bicep/child_modules/avd.bicep
@@ -8,7 +8,7 @@ param tags object = {}
 var baseName = !empty(subwloadname) ? replace(namingStructure, '{subwloadname}', subwloadname) : replace(namingStructure, '-{subwloadname}', '')
 
 // Create a host pool for AVD
-resource hostPool 'Microsoft.DesktopVirtualization/hostPools@2021-09-03-preview' = {
+resource hostPool 'Microsoft.DesktopVirtualization/hostPools@2021-01-14-preview' = {
   name: replace(baseName, '{rtype}', 'hp')
   location: location
   properties: {

--- a/arm_templates/azuredeploy.json
+++ b/arm_templates/azuredeploy.json
@@ -2586,7 +2586,7 @@
                   "resources": [
                     {
                       "type": "Microsoft.DesktopVirtualization/hostPools",
-                      "apiVersion": "2021-09-03-preview",
+                      "apiVersion": "2021-01-14-preview",
                       "name": "[replace(variables('baseName'), '{rtype}', 'hp')]",
                       "location": "[parameters('location')]",
                       "properties": {
@@ -2654,7 +2654,7 @@
                   "outputs": {
                     "hostpoolRegistrationToken": {
                       "type": "string",
-                      "value": "[reference(resourceId('Microsoft.DesktopVirtualization/hostPools', replace(variables('baseName'), '{rtype}', 'hp')), '2021-09-03-preview').registrationInfo.token]"
+                      "value": "[reference(resourceId('Microsoft.DesktopVirtualization/hostPools', replace(variables('baseName'), '{rtype}', 'hp')), '2021-01-14-preview').registrationInfo.token]"
                     },
                     "hostpoolName": {
                       "type": "string",


### PR DESCRIPTION
Changed the API version for AVD host pool to an older version because as of November 2022; RP( resource Provider) changed the emitter to always add API versions to resource references, so that each reference uses the response from a GET call instead of PUT request.

According to RP, registrationToken property is a secret, which means it should not be accessed directly anyway. 
The recommended way to access a secret property is to use the [list*](https://learn.microsoft.com/en-us/azure/azure-resource-manager/templates/template-functions-resource#list) function. The RP does expose a POST method retrieveRegistrationToken for getting registrationToken, but since the method name doesn't start with list, it won't work with Bicep / ARM templates. To fix the issue the RP will need to:

Mark the registrationToken as secret in Swagger to block direct access to the registrationToken property
Expose a new listRegistrationToken API so that we can call hostpools.listRegistrationToken() in Bicep to access the property.